### PR TITLE
[Test] BDD Module UnitTest - App & Presentation Layer & AudioService

### DIFF
--- a/CasualConversation/Project.swift
+++ b/CasualConversation/Project.swift
@@ -5,6 +5,7 @@ import MyPlugin
 // Local plugin loaded
 let localHelper = LocalHelper(name: "MyPlugin")
 
+// MARK: - Project String Data
 enum PSE {
 	static let projectName = "CasualConversation"
 	static let organizationName = "pseapplications"
@@ -38,7 +39,7 @@ func makeModule(layer: CleanArchitecture, dependencies: [CleanArchitecture]) -> 
 		productName: nil,
 		bundleId: "\(PSE.bundleId).\(layer.name)",
 		deploymentTarget: PSE.deploymentTarget,
-//		infoPlist: .default,
+		infoPlist: .default,
 		sources: ["Targets/\(layer.name)/Sources/**"],
 		resources: nil,
 		copyFiles: nil,
@@ -57,11 +58,13 @@ func makeModule(layer: CleanArchitecture, dependencies: [CleanArchitecture]) -> 
 		platform: .iOS,
 		product: .unitTests,
 		bundleId: "\(PSE.bundleId).DomainTests",
-//		infoPlist: .default,
+		infoPlist: .default,
 		sources: ["Targets/\(layer.name)/Tests/**"],
 		resources: [],
 		dependencies: [
-			.target(name: "\(layer.name)")
+			.target(name: "\(layer.name)"),
+			.quick,
+			.nimble
 		]
 	)
 	return [sources, tests]
@@ -84,41 +87,42 @@ let infoPlist: [String: InfoPlist.Value] = [
 ]
 
 let mainAppTarget = [
-	Target(
-	name: PSE.projectName,
-	platform: .iOS,
-	product: .app,
-	productName: nil,
-	bundleId: "\(PSE.bundleId).\(PSE.projectName)",
-	deploymentTarget: PSE.deploymentTarget,
-	infoPlist: .extendingDefault(with: infoPlist),
-	sources: ["Targets/\(PSE.projectName)/Sources/**"],
-	resources: ["Targets/\(PSE.projectName)/Resources/**"],
-	copyFiles: nil,
-	headers: nil,
-	entitlements: nil,
-	scripts: [],
-	dependencies: [
-		.target(name: CleanArchitecture.common.name),
-		.target(name: CleanArchitecture.presentation.name),
-		.target(name: CleanArchitecture.domain.name),
-		.target(name: CleanArchitecture.data.name)//,
-//		.swinject,
-//		.swinjectAutoregistration
-	],
-	settings: nil,
-	coreDataModels: [],
-	environment: [:],
-	launchArguments: [],
-	additionalFiles: []),
-	Target(
+	Target.init(
+		name: PSE.projectName,
+		platform: .iOS,
+		product: .app,
+		productName: nil,
+		bundleId: "\(PSE.bundleId).\(PSE.projectName)",
+		deploymentTarget: PSE.deploymentTarget,
+		infoPlist: .extendingDefault(with: infoPlist),
+		sources: ["Targets/\(PSE.projectName)/Sources/**"],
+		resources: ["Targets/\(PSE.projectName)/Resources/**"],
+		copyFiles: nil,
+		headers: nil,
+		entitlements: nil,
+		scripts: [],
+		dependencies: [
+			.target(name: CleanArchitecture.common.name),
+			.target(name: CleanArchitecture.presentation.name),
+			.target(name: CleanArchitecture.domain.name),
+			.target(name: CleanArchitecture.data.name)//,
+//			.swinject,
+//			.swinjectAutoregistration
+		],
+		settings: nil,
+		coreDataModels: [],
+		environment: [:],
+		launchArguments: [],
+		additionalFiles: []
+	),
+	Target.init(
 		name: "\(PSE.projectName)Tests",
 		platform: .iOS,
 		product: .unitTests,
 		productName: nil,
 		bundleId: "\(PSE.bundleId).\(PSE.projectName)Tests",
 		deploymentTarget: PSE.deploymentTarget,
-//		infoPlist: .default,
+		infoPlist: .default,
 		sources: ["Targets/\(PSE.projectName)/Tests/**"],
 		resources: nil,
 		copyFiles: nil,
@@ -126,7 +130,9 @@ let mainAppTarget = [
 		entitlements: nil,
 		scripts: [],
 		dependencies: [
-			.target(name: PSE.projectName)
+			.target(name: PSE.projectName),
+			.quick,
+			.nimble
 		],
 		settings: nil,
 		coreDataModels: [],
@@ -136,28 +142,28 @@ let mainAppTarget = [
 	)
 ]
 
-let project = Project
-	.init(
-		name: PSE.projectName,
-		organizationName: PSE.organizationName,
-		// options
-		packages: [
+let project = Project.init(
+	name: PSE.projectName,
+	organizationName: PSE.organizationName,
+	packages: [
+		.quick,
+		.nimble//,
 //			.swinject,
 //			.swinjectAutoregistration
-		],
-		settings: .settings(configurations: [
-			.debug(name: "Debug"),
-			.release(name: "Release")
-		]),
-		targets: [
-			mainAppTarget,
-			commonModule,
-			presentationModule,
-			domainModule,
-			dataModule,
-		].flatMap { $0 },
-		schemes: [],
-		fileHeaderTemplate: nil,
-		additionalFiles: [],
-		resourceSynthesizers: []
-	)
+	],
+	settings: .settings(configurations: [
+		.debug(name: "Debug"),
+		.release(name: "Release")
+	]),
+	targets: [
+		mainAppTarget,
+		commonModule,
+		presentationModule,
+		domainModule,
+		dataModule,
+	].flatMap { $0 },
+	schemes: [],
+	fileHeaderTemplate: nil,
+	additionalFiles: [],
+	resourceSynthesizers: []
+)

--- a/CasualConversation/Targets/CasualConversation/Tests/CasualConversationTests.swift
+++ b/CasualConversation/Targets/CasualConversation/Tests/CasualConversationTests.swift
@@ -2,7 +2,9 @@ import Foundation
 import XCTest
 
 final class CasualConversationTests: XCTestCase {
+	
     func test_twoPlusTwo_isFour() {
         XCTAssertEqual(2+2, 4)
     }
+	
 }

--- a/CasualConversation/Targets/CasualConversation/Tests/Specs/DIContainer/AppDIContainerSpecs.swift
+++ b/CasualConversation/Targets/CasualConversation/Tests/Specs/DIContainer/AppDIContainerSpecs.swift
@@ -1,0 +1,49 @@
+//
+//  AppDIContainerSpecs.swift
+//  CasualConversation
+//
+//  Created by Yongwoo Marco on 2022/07/13.
+//  Copyright © 2022 pseapplications. All rights reserved.
+//
+
+@testable import CasualConversation
+
+import Quick
+import Nimble
+
+import Foundation
+
+final class AppDIContainerSpecs: QuickSpec {
+	
+	override func spec() {
+		
+		var appDIContainer: AppDIContainer!
+		
+		beforeEach {
+			appDIContainer = AppDIContainer()
+		}
+		
+		describe("Factory Methods") {
+			
+			context("call makePresentationDIContainer()") {
+				
+				it("return PresentationDIContainer instance") {
+					let presentationDIContainer = appDIContainer.makePresentationDIContainer()
+					
+					expect(presentationDIContainer).notTo(beNil())
+				}
+			}
+			
+			context("call PresentationEntryPoint()") {
+
+				it("return MainTabView instance as View") {
+					let mainTabView = appDIContainer.PresentationEntryPoint()
+
+					expect(mainTabView).notTo(beNil())
+				}
+			}
+		}
+		
+	}
+	
+}

--- a/CasualConversation/Targets/CasualConversation/Tests/Specs/DIContainer/AppDIContainerSpecs.swift
+++ b/CasualConversation/Targets/CasualConversation/Tests/Specs/DIContainer/AppDIContainerSpecs.swift
@@ -11,8 +11,6 @@
 import Quick
 import Nimble
 
-import Foundation
-
 final class AppDIContainerSpecs: QuickSpec {
 	
 	override func spec() {

--- a/CasualConversation/Targets/Data/Tests/DataLayerTests.swift
+++ b/CasualConversation/Targets/Data/Tests/DataLayerTests.swift
@@ -2,7 +2,9 @@ import Foundation
 import XCTest
 
 final class DataLayerTests: XCTestCase {
+		
     func test_example() {
-        XCTAssertEqual("Data", "Data")
+        XCTAssertEqual("DataLayer", "DataLayer")
     }
+	
 }

--- a/CasualConversation/Targets/Data/Tests/Specs/RecordRepositorySpecs.swift
+++ b/CasualConversation/Targets/Data/Tests/Specs/RecordRepositorySpecs.swift
@@ -11,7 +11,6 @@
 import Quick
 import Nimble
 
-import Foundation
 import AVFAudio
 
 final class RecordRepositorySpecs: QuickSpec {
@@ -26,8 +25,8 @@ final class RecordRepositorySpecs: QuickSpec {
 			beforeSuite {
 				fileManagerRepository = FileManagerRepository()
 				recordRepository = RecordRepository(dependency: .init(
-					repository: fileManagerRepository
-				)
+						repository: fileManagerRepository
+					)
 				)
 			}
 			
@@ -36,47 +35,31 @@ final class RecordRepositorySpecs: QuickSpec {
 				recordRepository = nil
 			}
 			
-			
-			context("FactoryMethods") {
+			context("FactoryMethods - by FileManagerRepository") {
 				
 				it("call func makeAudioRecorder then AVAudioRecorder instance as AudioRecorderProtocol") {
 					// Arrange
-					var recorder: AVAudioRecorder
+					var recorder: AVAudioRecorder?
 					
 					// Act
-					recorder = recordRepository.makeAudioRecorder()!
+					recorder = recordRepository.makeAudioRecorder() as! AVAudioRecorder?
 					
 					// Assert
 					expect(recorder).notTo(beNil())
 					expect(recorder).to(beAKindOf(AVAudioRecorder.self))
 				}
-			}
-			
-			// TODO: 임시 파일이 필요함 실제로 읽을 수 있는 filePath 필요
-//			it("call makeAudioPlayer(_:) then AVAudioPlayer as AudioPlayerProtocol") {
-//				// Arrange
-//				let filePath = URL(fileURLWithPath: "newFilePath")
-//				var player: AVAudioPlayer?
-//
-//				// Act
-//				player = recordRepository.makeAudioPlayer(from: filePath) as? AVaudioPlayer
-//
-//
-//				// Assert
-//				expect(player).notTo(beNil())
-//				expect(player).to(beAKindOf(AVAudioPlayer.self))
-//			}
-			
-			it("call func makeAudioPlayer by incorrect filePath then nil") {
-				// Arrange
-				let filePath = URL(fileURLWithPath: "failurePath")
-				var player: AVAudioPlayer?
 				
-				// Act
-				player = recordRepository.makeAudioPlayer(from: filePath) as? AVAudioPlayer
-				
-				// Assert
-				expect(player).to(beNil())
+				it("call func makeAudioPlayer by incorrect filePath then nil") {
+					// Arrange
+					let filePath = URL(fileURLWithPath: "failurePath")
+					var player: AVAudioPlayer?
+					
+					// Act
+					player = recordRepository.makeAudioPlayer(from: filePath) as? AVAudioPlayer
+					
+					// Assert
+					expect(player).to(beNil())
+				}
 			}
 		}
 	}

--- a/CasualConversation/Targets/Data/Tests/Specs/RecordRepositorySpecs.swift
+++ b/CasualConversation/Targets/Data/Tests/Specs/RecordRepositorySpecs.swift
@@ -1,5 +1,5 @@
 //
-//  RecorderRepositorySpecs.swift
+//  RecordRepositorySpecs.swift
 //  DataTests
 //
 //  Created by Yongwoo Marco on 2022/07/12.
@@ -14,16 +14,24 @@ import Nimble
 import Foundation
 import AVFAudio
 
-final class RecorderRepositorySpecs: QuickSpec {
+final class RecordRepositorySpecs: QuickSpec {
 	
 	override func spec() {
 		
 		var fileManagerRepository: FileManagerRepository!
 		var recordRepository: RecordRepository!
 		
-		beforeEach {
+		beforeSuite {
 			fileManagerRepository = FileManagerRepository()
-			recordRepository = RecordRepository(dependency: .init(repository: fileManagerRepository))
+			recordRepository = RecordRepository(dependency: .init(
+					repository: fileManagerRepository
+				)
+			)
+		}
+		
+		afterSuite {
+			fileManagerRepository = nil
+			recordRepository = nil
 		}
 		
 		describe("Factory Methods") {
@@ -37,7 +45,7 @@ final class RecorderRepositorySpecs: QuickSpec {
 				}
 			}
 			
-			// 임시 파일이 필요함
+			// TODO: 임시 파일이 필요함 실제로 읽을 수 있는 filePath 필요
 //			context("call makeAudioPlayer(_:)") {
 //				let filePath = URL(fileURLWithPath: "newFilePath")
 //

--- a/CasualConversation/Targets/Data/Tests/Specs/RecordRepositorySpecs.swift
+++ b/CasualConversation/Targets/Data/Tests/Specs/RecordRepositorySpecs.swift
@@ -21,52 +21,63 @@ final class RecordRepositorySpecs: QuickSpec {
 		var fileManagerRepository: FileManagerRepository!
 		var recordRepository: RecordRepository!
 		
-		beforeSuite {
-			fileManagerRepository = FileManagerRepository()
-			recordRepository = RecordRepository(dependency: .init(
+		describe("as RecordRepository") {
+		
+			beforeSuite {
+				fileManagerRepository = FileManagerRepository()
+				recordRepository = RecordRepository(dependency: .init(
 					repository: fileManagerRepository
 				)
-			)
-		}
-		
-		afterSuite {
-			fileManagerRepository = nil
-			recordRepository = nil
-		}
-		
-		describe("Factory Methods") {
+				)
+			}
 			
-			context("call makeAudioRecorder()") {
-				it("return AVAudioRecorder instance as AudioRecorderProtocol") {
-					let recorder = recordRepository.makeAudioRecorder()
+			afterSuite {
+				fileManagerRepository = nil
+				recordRepository = nil
+			}
+			
+			
+			context("FactoryMethods") {
+				
+				it("call func makeAudioRecorder then AVAudioRecorder instance as AudioRecorderProtocol") {
+					// Arrange
+					var recorder: AVAudioRecorder
 					
+					// Act
+					recorder = recordRepository.makeAudioRecorder()!
+					
+					// Assert
 					expect(recorder).notTo(beNil())
 					expect(recorder).to(beAKindOf(AVAudioRecorder.self))
 				}
 			}
 			
 			// TODO: 임시 파일이 필요함 실제로 읽을 수 있는 filePath 필요
-//			context("call makeAudioPlayer(_:)") {
+//			it("call makeAudioPlayer(_:) then AVAudioPlayer as AudioPlayerProtocol") {
+//				// Arrange
 //				let filePath = URL(fileURLWithPath: "newFilePath")
+//				var player: AVAudioPlayer?
 //
-//				it("return AVAudioPlayer as AudioPlayerProtocol") {
-//					let player = recordRepository.makeAudioPlayer(from: filePath)
+//				// Act
+//				player = recordRepository.makeAudioPlayer(from: filePath) as? AVaudioPlayer
 //
-//					expect(player).notTo(beNil())
-//					expect(player).to(beAKindOf(AVAudioPlayer.self))
-//				}
+//
+//				// Assert
+//				expect(player).notTo(beNil())
+//				expect(player).to(beAKindOf(AVAudioPlayer.self))
 //			}
 			
-			context("call makeAudioPlayer(_:) by incorrect filePath") {
+			it("call func makeAudioPlayer by incorrect filePath then nil") {
+				// Arrange
 				let filePath = URL(fileURLWithPath: "failurePath")
+				var player: AVAudioPlayer?
 				
-				it("return nil") {
-					let player = recordRepository.makeAudioPlayer(from: filePath)
-					
-					expect(player).to(beNil())
-				}
+				// Act
+				player = recordRepository.makeAudioPlayer(from: filePath) as? AVAudioPlayer
+				
+				// Assert
+				expect(player).to(beNil())
 			}
 		}
 	}
-	
 }

--- a/CasualConversation/Targets/Data/Tests/Specs/RecorderRepositorySpecs.swift
+++ b/CasualConversation/Targets/Data/Tests/Specs/RecorderRepositorySpecs.swift
@@ -6,43 +6,56 @@
 //  Copyright © 2022 pseapplications. All rights reserved.
 //
 
-import Foundation
+@testable import Data
+
 import Quick
 import Nimble
-@testable import Data
+
+import Foundation
+import AVFAudio
 
 final class RecorderRepositorySpecs: QuickSpec {
 	
-	var repository: RecordRepository
-	
-	beforeEach {
-		repository = RecordRepository()
-	}
-	
 	override func spec() {
-		description("Factory Methods") {
-			let nowDate = Date()
+		
+		var fileManagerRepository: FileManagerRepository!
+		var recordRepository: RecordRepository!
+		
+		beforeEach {
+			fileManagerRepository = FileManagerRepository()
+			recordRepository = RecordRepository(dependency: .init(repository: fileManagerRepository))
+		}
+		
+		describe("Factory Methods") {
 			
 			context("call makeAudioRecorder()") {
-				let prefixOffset = 10 // 2022.00.00
-				let nowDateStringPrefix = nowDate.formatted(.dateTime).prefix(prefixOffset)
-				
-				it("return AVAudioRecorder as AudioRecorderProtocol") {
-					let recorder = repository.makeAudioRecorder()
+				it("return AVAudioRecorder instance as AudioRecorderProtocol") {
+					let recorder = recordRepository.makeAudioRecorder()
 					
-					expect(recorder?.url.description.prefix(prefixOffset))
-						.to(equal(nowDate.formatted(.dateTime).prefix(prefixOffset)))
+					expect(recorder).notTo(beNil())
+					expect(recorder).to(beAKindOf(AVAudioRecorder.self))
 				}
 			}
 			
-			context("call makeAudioPlayer(_:)") {
-				let filePath = URL(fileURLWithPath: "newFilePath")
+			// 임시 파일이 필요함
+//			context("call makeAudioPlayer(_:)") {
+//				let filePath = URL(fileURLWithPath: "newFilePath")
+//
+//				it("return AVAudioPlayer as AudioPlayerProtocol") {
+//					let player = recordRepository.makeAudioPlayer(from: filePath)
+//
+//					expect(player).notTo(beNil())
+//					expect(player).to(beAKindOf(AVAudioPlayer.self))
+//				}
+//			}
+			
+			context("call makeAudioPlayer(_:) by incorrect filePath") {
+				let filePath = URL(fileURLWithPath: "failurePath")
 				
-				it("return AVAudioPlayer as AudioPlayerProtocol") {
-					let player = repository.makeAudioPlayer(from: filePath)
+				it("return nil") {
+					let player = recordRepository.makeAudioPlayer(from: filePath)
 					
-					expect(player?.url!)
-						.to(filePath)
+					expect(player).to(beNil())
 				}
 			}
 		}

--- a/CasualConversation/Targets/Domain/Sources/Interface/Service/AudioRecorderProtocol.swift
+++ b/CasualConversation/Targets/Domain/Sources/Interface/Service/AudioRecorderProtocol.swift
@@ -9,7 +9,7 @@
 import Foundation
 import AVFAudio
 
-public protocol AudioRecorderProtocol where Self: AVAudioRecorder {
+public protocol AudioRecorderProtocol {
 	var delegate: AVAudioRecorderDelegate? { get set }
 	var url: URL { get }
 	var isRecording: Bool { get }

--- a/CasualConversation/Targets/Domain/Sources/Model/Conversation.swift
+++ b/CasualConversation/Targets/Domain/Sources/Model/Conversation.swift
@@ -15,6 +15,6 @@ public struct Conversation: UUIDIdentifiable {
     var topic: String?
     let members: [Member]
     let recordFilePath: URL
-    let recordedDate: Data
+    let recordedDate: Date
     
 }

--- a/CasualConversation/Targets/Domain/Sources/UseCase/ConversationUseCase.swift
+++ b/CasualConversation/Targets/Domain/Sources/UseCase/ConversationUseCase.swift
@@ -11,19 +11,19 @@ import Foundation
 
 
 public protocol ConversationRecodable {
-	func startRecording()
+	func startRecording() -> Bool
 	func pauseRecording()
 	func stopRecording(completion: (URL?) -> ())
 	func createConversation(with filePath: URL)
 }
 
 public protocol ConversationMaintainable {
-	func startPlayingAudio(from selectedConversation: Conversation)
-	func stopPlayingAudio()
+	func startPlaying(from selectedConversation: Conversation) -> Bool
+	func stopPlaying()
 	func pausePlaying()
 }
 
-public protocol ConversationUseCaseManagable: ConversationRecodable, ConversationMaintainable  { }
+public protocol ConversationUseCaseManagable: ConversationRecodable, ConversationMaintainable { }
 
 public final class ConversationUseCase: Dependency, ConversationUseCaseManagable {
 	
@@ -53,9 +53,12 @@ public final class ConversationUseCase: Dependency, ConversationUseCaseManagable
 // MARK: - ConversationRecodable
 extension ConversationUseCase {
 	
-	public func startRecording() {
-		self.dependency.audioService.setupRecorder()
-		self.dependency.audioService.startRecording()
+	public func startRecording() -> Bool {
+		if self.dependency.audioService.setupRecorder() {
+			return self.dependency.audioService.startRecording()
+		} else {
+			return false
+		}
 	}
 
 	public func pauseRecording() {
@@ -77,13 +80,16 @@ extension ConversationUseCase {
 // MARK: - ConversationMaintainable
 extension ConversationUseCase {
 	
-	public func startPlayingAudio(from selectedConversation: Conversation) {
+	public func startPlaying(from selectedConversation: Conversation) -> Bool {
 		let filePath = selectedConversation.recordFilePath
-		self.dependency.audioService.setupPlaying(from: filePath)
-		self.dependency.audioService.playAudio()
+		if self.dependency.audioService.setupPlaying(from: filePath) {
+			return self.dependency.audioService.startPlaying()
+		} else {
+			return false
+		}
 	}
 	
-	public func stopPlayingAudio() {
+	public func stopPlaying() {
 		self.dependency.audioService.stopPlaying()
 	}
 	

--- a/CasualConversation/Targets/Domain/Tests/DomainTests.swift
+++ b/CasualConversation/Targets/Domain/Tests/DomainTests.swift
@@ -2,7 +2,9 @@ import Foundation
 import XCTest
 
 final class DomainTests: XCTestCase {
+	
     func test_example() {
         XCTAssertEqual("Domain", "Domain")
     }
+	
 }

--- a/CasualConversation/Targets/Domain/Tests/Specs/Mocks/MockAudioPlayer.swift
+++ b/CasualConversation/Targets/Domain/Tests/Specs/Mocks/MockAudioPlayer.swift
@@ -1,0 +1,49 @@
+//
+//  MockAudioPlayer.swift
+//  DomainTests
+//
+//  Created by Yongwoo Marco on 2022/07/14.
+//  Copyright © 2022 pseapplications. All rights reserved.
+//
+
+@testable import Domain
+
+import Foundation
+import AVFAudio
+
+final class MockAudioPlayer: AudioPlayerProtocol {
+	var delegate: AVAudioPlayerDelegate?
+	var url: URL?
+	var isPlaying: Bool = false
+	
+	init(delegate: AVAudioPlayerDelegate?, url: URL?) {
+		self.delegate = delegate
+		self.url = url
+	}
+	
+	var currentTime: TimeInterval {
+		0.0
+	}
+	var duration: TimeInterval {
+		10.0
+	}
+	
+	func prepareToPlay() -> Bool {
+		isPlaying = false
+		return true
+	}
+	
+	func play() -> Bool {
+		isPlaying = true
+		return true
+	}
+	
+	func pause() {
+		isPlaying = false
+	}
+	
+	func stop() {
+		isPlaying = false
+	}
+	
+}

--- a/CasualConversation/Targets/Domain/Tests/Specs/Mocks/MockAudioRecorder.swift
+++ b/CasualConversation/Targets/Domain/Tests/Specs/Mocks/MockAudioRecorder.swift
@@ -1,0 +1,47 @@
+//
+//  MockAudioRecorder.swift
+//  DomainTests
+//
+//  Created by Yongwoo Marco on 2022/07/14.
+//  Copyright © 2022 pseapplications. All rights reserved.
+//
+
+@testable import Domain
+
+import Foundation
+import AVFAudio
+
+final class MockAudioRecorder: AudioRecorderProtocol {
+	var delegate: AVAudioRecorderDelegate?
+	var url: URL
+	var isRecording: Bool = false
+	
+	init(delegate: AVAudioPlayerDelegate?, url: URL) {
+		self.delegate = delegate as? AVAudioRecorderDelegate
+		self.url = url
+	}
+	
+	var currentTime: TimeInterval {
+		0.0
+	}
+	
+	func prepareToRecord() -> Bool {
+		isRecording = false
+		return true
+	}
+	
+	func record() -> Bool {
+		isRecording = true
+		return true
+	}
+	
+	func pause() {
+		isRecording = false
+	}
+	
+	func stop() {
+		isRecording = false
+	}
+	
+}
+

--- a/CasualConversation/Targets/Domain/Tests/Specs/Mocks/MockRecordRepository.swift
+++ b/CasualConversation/Targets/Domain/Tests/Specs/Mocks/MockRecordRepository.swift
@@ -1,0 +1,30 @@
+//
+//  MockRecordRepository.swift
+//  CasualConversation
+//
+//  Created by Yongwoo Marco on 2022/07/13.
+//  Copyright © 2022 pseapplications. All rights reserved.
+//
+
+@testable import Domain
+
+import Foundation
+import AVFAudio
+
+struct MockRecordRepository {
+	
+	private var directory = FileManager.default.temporaryDirectory
+	
+}
+
+extension MockRecordRepository: RecordRepositoryProtocol {
+	
+	public func makeAudioRecorder() -> AudioRecorderProtocol? {
+		return MockAudioRecorder(delegate: nil, url: URL(string: "fake")!)
+	}
+	
+	public func makeAudioPlayer(from filePath: URL) -> AudioPlayerProtocol? {
+		return MockAudioPlayer(delegate: nil, url: filePath)
+	}
+	
+}

--- a/CasualConversation/Targets/Domain/Tests/Specs/Service/AudioServiceSpecs.swift
+++ b/CasualConversation/Targets/Domain/Tests/Specs/Service/AudioServiceSpecs.swift
@@ -1,0 +1,159 @@
+//
+//  AudioServiceSpecs.swift
+//  CasualConversation
+//
+//  Created by Yongwoo Marco on 2022/07/13.
+//  Copyright © 2022 pseapplications. All rights reserved.
+//
+
+@testable import Domain
+
+import Quick
+import Nimble
+
+import Foundation
+
+final class AudioServiceSpecs: QuickSpec {
+	
+	override func spec() {
+		
+		var recordRepository: RecordRepositoryProtocol!
+		var audioService: AudioServiceProtocol!
+		
+		describe("as AudioServiceProtocol") {
+			
+			beforeSuite {
+				recordRepository = MockRecordRepository()
+				audioService = AudioService(dependency: .init(
+						repository: recordRepository
+					)
+				)
+			}
+			
+			afterSuite {
+				recordRepository = nil
+				audioService = nil
+			}
+			
+			context("Adopted AudioPlayable") {
+				var audioPlayable: AudioPlayable!
+				
+				beforeEach {
+					audioPlayable = audioService
+				}
+				
+				afterEach {
+					audioPlayable = nil
+				}
+				
+				it("call setupRecorder then currentPlayingTime eqaul 0.0") {
+					// Arrange
+					let filePath = URL(fileURLWithPath: "")
+					
+					// Act
+					_ = audioPlayable.setupPlaying(from: filePath)
+					
+					// Assert
+					expect(audioPlayable.currentPlayingTime).to(equal(TimeInterval(0.0)))
+				}
+				
+				it("call func startPlaying then status eqaul .playing") {
+					// Arrange
+					
+					// Act
+					_ = audioPlayable.startPlaying()
+					
+					// Assert
+					expect(audioPlayable.status).to(equal(.playing))
+				}
+				
+				it("call func setupRecorder then currentPlayingTime eqaul 0.0") {
+					// Arrange
+					let filePath = URL(fileURLWithPath: "")
+					
+					// Act
+					_ = audioPlayable.setupPlaying(from: filePath)
+					
+					// Assert
+					expect(audioPlayable.currentPlayingTime).to(equal(TimeInterval(0.0)))
+				}
+				
+				it("call func pausePlaying then status eqaul .paused") {
+					// Arrange
+					_ = audioPlayable.startPlaying()
+					
+					// Act
+					audioPlayable.pausePlaying()
+					
+					// Assert
+					expect(audioPlayable.status).to(equal(.paused))
+				}
+				
+				it("call func stopPlaying then status eqaul .stopped") {
+					// Arrange
+					_ = audioPlayable.startPlaying()
+					
+					// Act
+					audioPlayable.stopPlaying()
+					
+					// Assert
+					expect(audioPlayable.status).to(equal(.stopped))
+				}
+			}
+			
+			context("Adopted AudioRecordable") {
+				var audioRecordable: AudioRecordable!
+				
+				beforeEach {
+					audioRecordable = audioService
+				}
+				
+				afterEach {
+					audioRecordable = nil
+				}
+				
+				it("func call setupRecorder then currentRecordingTime eqaul 0.0") {
+					// Arrange
+					
+					// Act
+					_ = audioRecordable.setupRecorder()
+					
+					// Assert
+					expect(audioRecordable.currentRecordingTime).to(equal(TimeInterval(0.0)))
+				}
+				
+				it("func call startRecording then status eqaul .recording") {
+					// Arrange
+					
+					// Act
+					_ = audioRecordable.startRecording()
+					
+					// Assert
+					expect(audioService.status).to(equal(.recording))
+				}
+				
+				it("func call pauseRecording then status eqaul .paused") {
+					// Arrange
+					_ = audioRecordable.startRecording()
+					
+					// Act
+					_ = audioRecordable.pauseRecording()
+					
+					// Assert
+					expect(audioRecordable.status).to(equal(.paused))
+				}
+				
+				it("func call stopRecording then status eqaul .stopped") {
+					// Arrange
+					_ = audioRecordable.startRecording()
+					
+					// Act
+					_ = audioRecordable.stopRecording()
+					
+					// Assert
+					expect(audioRecordable.status).to(equal(.stopped))
+				}
+			}
+		}
+	}
+}

--- a/CasualConversation/Targets/Domain/Tests/Specs/Service/AudioServiceSpecs.swift
+++ b/CasualConversation/Targets/Domain/Tests/Specs/Service/AudioServiceSpecs.swift
@@ -67,17 +67,6 @@ final class AudioServiceSpecs: QuickSpec {
 					expect(audioPlayable.status).to(equal(.playing))
 				}
 				
-				it("call func setupRecorder then currentPlayingTime eqaul 0.0") {
-					// Arrange
-					let filePath = URL(fileURLWithPath: "")
-					
-					// Act
-					_ = audioPlayable.setupPlaying(from: filePath)
-					
-					// Assert
-					expect(audioPlayable.currentPlayingTime).to(equal(TimeInterval(0.0)))
-				}
-				
 				it("call func pausePlaying then status eqaul .paused") {
 					// Arrange
 					_ = audioPlayable.startPlaying()

--- a/CasualConversation/Targets/Presentation/Sources/DIContainer/PresentationDIContainer.swift
+++ b/CasualConversation/Targets/Presentation/Sources/DIContainer/PresentationDIContainer.swift
@@ -1,5 +1,5 @@
 //
-//  SceneDIContainer.swift
+//  PresentationDIContainer.swift
 //  CasualConversation
 //
 //  Created by Yongwoo Marco on 2022/07/03.

--- a/CasualConversation/Targets/Presentation/Tests/PresentationTests.swift
+++ b/CasualConversation/Targets/Presentation/Tests/PresentationTests.swift
@@ -2,7 +2,9 @@ import Foundation
 import XCTest
 
 final class PresentationTests: XCTestCase {
+	
     func test_example() {
         XCTAssertEqual("Presentation", "Presentation")
     }
+	
 }

--- a/CasualConversation/Targets/Presentation/Tests/Specs/DIContainer/PresentationDIContainerSpecs.swift
+++ b/CasualConversation/Targets/Presentation/Tests/Specs/DIContainer/PresentationDIContainerSpecs.swift
@@ -1,0 +1,98 @@
+//
+//  PresentationDIContainerSpecs.swift
+//  CasualConversation
+//
+//  Created by Yongwoo Marco on 2022/07/13.
+//  Copyright © 2022 pseapplications. All rights reserved.
+//
+
+@testable import Presentation
+@testable import Data
+@testable import Domain
+
+import Quick
+import Nimble
+
+import Foundation
+import SwiftUI
+
+extension Conversation {
+	
+	static let dummy: Conversation = .init(
+		id: UUID(), members: [], recordFilePath: URL(string: "dummy")!, recordedDate: Date()
+	)
+	
+}
+
+final class PresentationDIContainerSpecs: QuickSpec {
+	
+	override func spec() {
+		
+		var presentationDIContainerSpecs: PresentationDIContainer!
+		
+		beforeEach {
+			presentationDIContainerSpecs = PresentationDIContainer(dependency: .init(
+				conversationRepository: ConversationRepository(),
+				noteRepository: NoteRepository(),
+				recordRepository: RecordRepository(dependency: .init(
+							repository: FileManagerRepository()
+						)
+					)
+				)
+			)
+		}
+		
+		describe("as PresentationDIContainer") {
+			
+			context("FactoryMethods") {
+				
+				it("call func MainTabView then MainTabView instance as some View") {
+					// Arrange
+					let mainTabView: MainTabView
+					
+					// Act
+					mainTabView = presentationDIContainerSpecs.MainTabView()
+					
+					// Assert
+					expect(mainTabView).notTo(beNil())
+				}
+				
+				it("call func RecordView then RecordView instance as View") {
+					// Arrange
+					let recordView: RecordView
+					
+					// Act
+					recordView = presentationDIContainerSpecs.RecordView()
+					
+					// Assert
+					expect(recordView).notTo(beNil())
+				}
+				
+				it("call func SelectionView then SelectionView instance as View") {
+					// Arrange
+					let testConversation = Conversation.dummy
+					let selectionView: SelectionView
+					
+					// Act
+					selectionView = presentationDIContainerSpecs.SelectionView(selected: testConversation)
+					
+					// Assert
+					expect(selectionView).notTo(beNil())
+				}
+				
+				it("call func NoteSetView then NoteSetView instance as View") {
+					// Arrange
+					let recordView: NoteSetView
+					
+					// Act
+					recordView = presentationDIContainerSpecs.NoteSetView()
+					
+					// Assert
+					expect(recordView).notTo(beNil())
+				}
+			}
+		}
+		
+	}
+	
+}

--- a/CasualConversation/Targets/Presentation/Tests/Specs/DIContainer/PresentationDIContainerSpecs.swift
+++ b/CasualConversation/Targets/Presentation/Tests/Specs/DIContainer/PresentationDIContainerSpecs.swift
@@ -14,7 +14,6 @@ import Quick
 import Nimble
 
 import Foundation
-import SwiftUI
 
 extension Conversation {
 	
@@ -46,53 +45,40 @@ final class PresentationDIContainerSpecs: QuickSpec {
 			
 			context("FactoryMethods") {
 				
-				it("call func MainTabView then MainTabView instance as some View") {
-					// Arrange
+				it("call func MainTabView then MainTabView instance") {
 					let mainTabView: MainTabView
 					
-					// Act
 					mainTabView = presentationDIContainerSpecs.MainTabView()
 					
-					// Assert
 					expect(mainTabView).notTo(beNil())
 				}
 				
-				it("call func RecordView then RecordView instance as View") {
-					// Arrange
+				it("call func RecordView then RecordView instance") {
 					let recordView: RecordView
 					
-					// Act
 					recordView = presentationDIContainerSpecs.RecordView()
 					
-					// Assert
 					expect(recordView).notTo(beNil())
 				}
 				
-				it("call func SelectionView then SelectionView instance as View") {
-					// Arrange
+				it("call func SelectionView then SelectionView instance") {
 					let testConversation = Conversation.dummy
 					let selectionView: SelectionView
 					
-					// Act
 					selectionView = presentationDIContainerSpecs.SelectionView(selected: testConversation)
 					
-					// Assert
 					expect(selectionView).notTo(beNil())
 				}
 				
-				it("call func NoteSetView then NoteSetView instance as View") {
-					// Arrange
+				it("call func NoteSetView then NoteSetView instance") {
 					let recordView: NoteSetView
 					
-					// Act
 					recordView = presentationDIContainerSpecs.NoteSetView()
 					
-					// Assert
 					expect(recordView).notTo(beNil())
 				}
 			}
 		}
-		
 	}
 	
 }

--- a/CasualConversation/Tuist/ProjectDescriptionHelpers/Extensions.swift
+++ b/CasualConversation/Tuist/ProjectDescriptionHelpers/Extensions.swift
@@ -10,6 +10,8 @@ import ProjectDescription
 public extension TargetDependency {
 //	static let swinject = TargetDependency.package(product: "Swinject")
 //	static let swinjectAutoregistration =  TargetDependency.package(product: "SwinjectAutoregistration")
+	static let quick: TargetDependency = .package(product: "Quick")
+	static let nimble: TargetDependency = .package(product: "Nimble")
 }
 
 public extension Package {
@@ -19,7 +21,13 @@ public extension Package {
 //	)
 //	static let swinjectAutoregistration = Package.remote(
 //		url: "https://github.com/Swinject/SwinjectAutoregistration.git",
-//		requirement: .upToNextMajor(from: .init(2, 8, 1)))
+	//		requirement: .upToNextMajor(from: .init(2, 8, 1)))
+	static let quick = Package.remote(
+		url: "https://github.com/Quick/Quick.git",
+		requirement: .upToNextMajor(from: .init(3, 0, 0)))
+	static let nimble = Package.remote(
+		url: "https://github.com/Quick/Nimble.git",
+		requirement: .upToNextMajor(from: .init(9, 0, 0)))
 }
 
 // MARK: - SourceFile


### PR DESCRIPTION
## 구현 배경
close #16  - Module UnitTest 구현
#17 - 5주차

## 기능 설명
### Data Layer 
* RecordRespositorySpecs - FactoryMethods 테스트
### Domain Layer
* Mock 객체 생성
   * MockRecordRepository: RecordRepositoryProtocol
   * MockAudioPlayer: AudioPlayerProtocol
   * MockAudioRecorder: AudioRecorderProtocol
   > AVAudioPlayer 및 AVAudioRecorder 생성이 안됩니다. (like URLSession 통신) 따라서 Mock 객체를 이용한 테스트 진행했습니다.
* AudioServiceSpecs - AudioServiceProtocol public Methods 테스트
### Presentation Layer
* PresentationDIContainerSpecs - FactoryMethods 테스트

### 코멘트
AudioService 기초 구현 마치고 해당 기능 UnitTest와
기존 App 트리거 및 PresentaionLayer에 구현한 DIContainer 기능 UnitTest를 진행했습니다.

앞으로 
CoreData 구현과 ConversationUseCase 및 NoteUseCase 구현을 진행하고 
위 구현 UnitTest 진행,

모두 완료하면 
AudioService Advanced Feature (핀 찍기, 넘기기, 재생속도 등) 
PresentationLayer (SwiftUI) 구현

순서로 진행 계획하고 있습니다.