### PR TITLE
Feature cc error

### DIFF
--- a/CasualConversation/.package.resolved
+++ b/CasualConversation/.package.resolved
@@ -1,21 +1,39 @@
 {
   "pins" : [
     {
-      "identity" : "swinject",
+      "identity" : "cwlcatchexception",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Swinject/Swinject.git",
+      "location" : "https://github.com/mattgallagher/CwlCatchException.git",
       "state" : {
-        "revision" : "f10b6e9ebff440f985c43008f7c2d097639fcb81",
-        "version" : "2.8.1"
+        "revision" : "35f9e770f54ce62dd8526470f14c6e137cef3eea",
+        "version" : "2.1.1"
       }
     },
     {
-      "identity" : "swinjectautoregistration",
+      "identity" : "cwlpreconditiontesting",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Swinject/SwinjectAutoregistration.git",
+      "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
       "state" : {
-        "revision" : "9936170fd1a5e8c141a21de987c48cc4e0d6c943",
-        "version" : "2.8.1"
+        "revision" : "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "nimble",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Nimble.git",
+      "state" : {
+        "revision" : "c93f16c25af5770f0d3e6af27c9634640946b068",
+        "version" : "9.2.1"
+      }
+    },
+    {
+      "identity" : "quick",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Quick.git",
+      "state" : {
+        "revision" : "8cce6acd38f965f5baa3167b939f86500314022b",
+        "version" : "3.1.2"
       }
     }
   ],

--- a/CasualConversation/Targets/Common/Sources/Error/CasualConversationError.swift
+++ b/CasualConversation/Targets/Common/Sources/Error/CasualConversationError.swift
@@ -31,7 +31,9 @@ public enum CCError: Error {
     
     // MARK: - Data
     public enum RepositoryFailureReason {
-        
+        case coreDataViewContextUnsaved(Error)
+        case coreDataUnloaded(Error)
+        case fileURLPathInvalidated
     }
     
     case persistenceFailed(reason: RepositoryFailureReason)

--- a/CasualConversation/Targets/Common/Sources/Error/CasualConversationError.swift
+++ b/CasualConversation/Targets/Common/Sources/Error/CasualConversationError.swift
@@ -16,6 +16,7 @@ public enum CCError: Error {
         case optionalBindingNotWork
     }
     
+    // MARK: - Domain
     public enum ConversationManageFailureReason {
         
     }
@@ -27,5 +28,12 @@ public enum CCError: Error {
     case systemErrorOccured(reason: SystemErrorReason)
     case conversationManageFailed(reason: ConversationManageFailureReason)
     case noteManageFailed(reason: NoteManageFailureReason)
+    
+    // MARK: - Data
+    public enum RepositoryFailureReason {
+        
+    }
+    
+    case persistenceFailed(reason: RepositoryFailureReason)
     
 }

--- a/CasualConversation/Targets/Common/Sources/Error/CasualConversationError.swift
+++ b/CasualConversation/Targets/Common/Sources/Error/CasualConversationError.swift
@@ -1,0 +1,31 @@
+//
+//  CasualConversationError.swift
+//  CasualConversation
+//
+//  Created by coda on 2022/07/23.
+//  Copyright © 2022 pseapplications. All rights reserved.
+//
+
+import Foundation
+
+public enum CCError: Error {
+    
+    public enum SystemErrorReason {
+        case escapingClosureIsLost
+        case typeCastingNotWork
+        case optionalBindingNotWork
+    }
+    
+    public enum ConversationManageFailureReason {
+        
+    }
+    
+    public enum NoteManageFailureReason {
+        
+    }
+    
+    case systemErrorOccured(reason: SystemErrorReason)
+    case conversationManageFailed(reason: ConversationManageFailureReason)
+    case noteManageFailed(reason: NoteManageFailureReason)
+    
+}


### PR DESCRIPTION
@keeplo 

### 기능요청 배경 설명
- Error 타입을 통합적으로 관리하기 위한 방법을 설계

### 솔루션 디테일 설명
- Alamofire의 에러 설계 방식을 차용하여, 두 개의 계층을 가진 Error 타입을 설계함
   - CCError: 첫번째 계층, case를 통해 대단위 에러 범주를 설정
   - Reason: 두번째 계층, 각 Error case의 세부적인 이유를 별도의 열거형을 통해 관리함